### PR TITLE
miniDRGN.py now recognizes the 'gaussian' enc_type

### DIFF
--- a/build/lib/chimerax/wiggle/deps/miniDRGN.py
+++ b/build/lib/chimerax/wiggle/deps/miniDRGN.py
@@ -1,3 +1,10 @@
+# @Original author: Ellen Zhong, MIT and Princeton University
+
+# @Modified by:   Charles Bayly-Jones, Monash University
+# @Last modified time: 07-Sep-2022
+
+# @License: GNU General Public License v3.0
+
 import pickle
 import torch
 import torch.nn as nn
@@ -5,6 +12,7 @@ import numpy as np
 from PyQt5 import QtCore
 import mrcfile
 import math
+from torch.nn.parameter import Parameter
 
 class params:
     def __init__(self, config, weights):
@@ -69,7 +77,8 @@ class HetOnlyVAE(nn.Module):
                  enc_type='linear_lowf',
                  enc_dim=None,
                  domain='fourier',
-                 activation=nn.ReLU):
+                 activation=nn.ReLU,
+                 feat_sigma=None):
         super(HetOnlyVAE, self).__init__()
         self.lattice = lattice
         self.zdim = zdim
@@ -98,7 +107,7 @@ class HetOnlyVAE(nn.Module):
         else:
             raise RuntimeError('Encoder mode {} not recognized'.format(encode_mode))
         self.encode_mode = encode_mode
-        self.decoder = self.get_decoder(3 + zdim, lattice.D, players, pdim, domain, enc_type, enc_dim, activation)
+        self.decoder = self.get_decoder(3 + zdim, lattice.D, players, pdim, domain, enc_type, enc_dim, activation, feat_sigma)
 
     @classmethod
     def load(self, config, weights=None, device=None):
@@ -133,7 +142,8 @@ class HetOnlyVAE(nn.Module):
                            enc_type=c['pe_type'],
                            enc_dim=c['pe_dim'],
                            domain=c['domain'],
-                           activation=activation)
+                           activation=activation,
+                           feat_sigma=c["feat_sigma"])
         if weights is not None:
             ckpt = torch.load(weights) if type(weights) is str else weights.flatten()[0]
             #ckpt = torch.load(weights)
@@ -178,7 +188,7 @@ class HetOnlyVAE(nn.Module):
     def forward(self, *args, **kwargs):
         return self.decode(*args, **kwargs)
 
-    def get_decoder(self, in_dim, D, layers, dim, domain, enc_type, enc_dim=None, activation=nn.ReLU):
+    def get_decoder(self, in_dim, D, layers, dim, domain, enc_type, enc_dim=None, activation=nn.ReLU, feat_sigma=None):
         if enc_type == 'none':
             if domain == 'hartley':
                 model = ResidLinearMLP(in_dim, layers, dim, 1, activation)
@@ -188,7 +198,7 @@ class HetOnlyVAE(nn.Module):
             return model
         else:
             model = PositionalDecoder if domain == 'hartley' else FTPositionalDecoder
-            return model(in_dim, D, layers, dim, activation, enc_type=enc_type, enc_dim=enc_dim)
+            return model(in_dim, D, layers, dim, activation, enc_type=enc_type, enc_dim=enc_dim, feat_sigma=feat_sigma)
 
 class Lattice:
     def __init__(self, D, extent=0.5, ignore_DC=True):
@@ -325,7 +335,7 @@ class Lattice:
         return c * img + s * img[:, :, np.arange(len(coords) - 1, -1, -1)]
 
 class FTPositionalDecoder(nn.Module):
-    def __init__(self, in_dim, D, nlayers, hidden_dim, activation, enc_type='linear_lowf', enc_dim=None):
+    def __init__(self, in_dim, D, nlayers, hidden_dim, activation, enc_type='linear_lowf', enc_dim=None, feat_sigma=None):
         super(FTPositionalDecoder, self).__init__()
         assert in_dim >= 3
         self.zdim = in_dim - 3
@@ -337,8 +347,25 @@ class FTPositionalDecoder(nn.Module):
         self.in_dim = 3 * (self.enc_dim) * 2 + self.zdim
         self.decoder = ResidLinearMLP(self.in_dim, nlayers, hidden_dim, 2, activation)
 
+        if enc_type == "gaussian":
+            # We construct 3 * self.enc_dim random vector frequences, to match the original positional encoding:
+            # In the positional encoding we produce self.enc_dim features for each of the x,y,z dimensions,
+            # whereas in gaussian encoding we produce self.enc_dim features each with random x,y,z components
+            #
+            # Each of the random feats is the sine/cosine of the dot product of the coordinates with a frequency
+            # vector sampled from a gaussian with std of feat_sigma
+            rand_freqs = (
+                torch.randn((3 * self.enc_dim, 3), dtype=torch.float) * feat_sigma
+            )
+            # make rand_feats a parameter so it is saved in the checkpoint, but do not perform SGD on it
+            self.rand_freqs = Parameter(rand_freqs, requires_grad=False)
+        else:
+            self.rand_feats = None
+
     def positional_encoding_geom(self, coords):
         '''Expand coordinates in the Fourier basis with geometrically spaced wavelengths from 2/D to 2pi'''
+        if self.enc_type == "gaussian":
+            return self.random_fourier_encoding(coords)
         freqs = torch.arange(self.enc_dim, dtype=torch.float)
         if self.enc_type == 'geom_ft':
             freqs = self.DD * np.pi * (2. / self.DD) ** (freqs / (self.enc_dim - 1))  # option 1: 2/D to 1
@@ -376,6 +403,24 @@ class FTPositionalDecoder(nn.Module):
         x = x.view(*coords.shape[:-2], self.in_dim - self.zdim)  # B x in_dim-zdim
         if self.zdim > 0:
             x = torch.cat([x, coords[..., 3:, :].squeeze(-1)], -1)
+            assert x.shape[-1] == self.in_dim
+        return x
+
+    def random_fourier_encoding(self, coords):
+        assert self.rand_freqs is not None
+        # k = coords . rand_freqs
+        # expand rand_freqs with singleton dimension along the batch dimensions
+        # e.g. dim (1, ..., 1, n_rand_feats, 3)
+        freqs = self.rand_freqs.view(*[1] * (len(coords.shape) - 1), -1, 3) * self.D2
+
+        kxkykz = coords[..., None, 0:3] * freqs  # compute the x,y,z components of k
+        k = kxkykz.sum(-1)  # compute k
+        s = torch.sin(k)
+        c = torch.cos(k)
+        x = torch.cat([s, c], -1)
+        x = x.view(*coords.shape[:-1], self.in_dim - self.zdim)
+        if self.zdim > 0:
+            x = torch.cat([x, coords[..., 3:]], -1)
             assert x.shape[-1] == self.in_dim
         return x
 
@@ -675,4 +720,3 @@ class miniDRGN(QtCore.QObject):
         self.args.downsample = self.downsample()
 
         self.done.emit()
-


### PR DESCRIPTION
- cryoDRGN [v1.0.0](https://github.com/ml-struct-bio/cryodrgn/releases/tag/1.0.0) implemented the  `gaussian` `enc_type`, which is now the default
- Added new logic to recognize the `gaussian` `enc_type` and read in the new `feat_sigma` parameter 